### PR TITLE
Metal back-propagation and grad-normalization pass

### DIFF
--- a/gpt2.metal
+++ b/gpt2.metal
@@ -874,7 +874,7 @@ kernel void encoder_backward_kernel(
     atomic_fetch_add_explicit(&dwpe[wpe_index], d, memory_order_relaxed);
 }
 
-kernel void adamw_kernel_opt(
+kernel void adamw_kernel(
     device float *params,
     device const float *grads,
     device float *m_memory,

--- a/metal_compute.h
+++ b/metal_compute.h
@@ -48,6 +48,7 @@ typedef enum MetalErrorCode {
   MetalErrorSetPipelineFailed,
   MetalErrorNotInitialized,
   MetalErrorBindArgFailed,
+  MetalErrorInvalidArgument,
   MetalErrorCount // Should always be last
 } MetalErrorCode;
 
@@ -71,6 +72,7 @@ static const char *MetalErrorStrings[MetalErrorCount] = {
     "Failed to create MPSMatrixMultiplication.",
     "Failed to set pipeline state on command encoder.",
     "Metal state is not yet initialized.",
+    "Invalid argument provided.",
     "Failed to bind an argument to kernel function."};
 
 void __metalCheck(MetalErrorCode error, const char *file, int line);

--- a/metal_compute.h
+++ b/metal_compute.h
@@ -154,4 +154,5 @@ MetalErrorCode metalSgemmBatched(bool leftT, bool rightT, size_t leftRows,
                                  size_t leftCols, size_t rightRows,
                                  size_t rightCols, float *A, float *B, float *C,
                                  size_t batchCount, float alpha, float beta);
+MetalErrorCode metalClearBuffer(void* buffer_base_ptr, size_t total_size_bytes);
 #endif /* metal_h */

--- a/metal_compute.m
+++ b/metal_compute.m
@@ -380,7 +380,7 @@ MetalErrorCode metalClearBuffer(void* buffer_base_ptr, size_t total_size_bytes)
         if (commitCode != MetalSuccess)
             returnError(commitCode);
 
-        [gMetakState.encoder endEncoding];
+        [gMetalState.encoder endEncoding];
          gMetalState.encoder = nil;
     } else {
         if (!gMetalState.commandBuffers || gMetalState.commandBuffers.count == 0) {
@@ -394,7 +394,7 @@ MetalErrorCode metalClearBuffer(void* buffer_base_ptr, size_t total_size_bytes)
     //get the command buffer and we will add Blit command to
     //blit --> Block image transfer (to fill block of texture or buffer memory)
     // the active commadn buffer is always the last one
-    id<MTLCommandBuffer> commandBuffer = [gMetalState.commandBuffers lastObject];
+    id<MTLCommandBuffer> currentCmdBuffer = [gMetalState.commandBuffers lastObject];
     if (!currentCmdBuffer){
        returnError(MetalErrorCommandBufferCreationFailed);
     }
@@ -417,7 +417,7 @@ MetalErrorCode metalClearBuffer(void* buffer_base_ptr, size_t total_size_bytes)
     [currentCmdBuffer commit];
 
     //remove the committed buffer
-    [gMetalSate.commandBuffers removeObject:currentCmdBuffer];
+    [gMetalState.commandBuffers removeObject:currentCmdBuffer];
 
     //Create a new command buffer and comptue encoder for subsequent compute tasks
     id<MTLCommandBuffer> nextCmdBuffer = createCommandBuffer();


### PR DESCRIPTION
Changes made: 
11 new compute kernels added for backward operations and for gradient clipping

Modified host code to properly allocate gradient tensors and call into the written kernels.

Training result -->

step 37: train loss 4.404222 (took 96.381000 ms)
step 38: train loss 4.812803 (took 97.004000 ms)
step 39: train loss 4.580478 (took 96.203000 ms)
val loss 4.741230
generating:
---
Hello weary traveler!I believe the harbor oss to be our book.If only you could like it or buy it? Please don't think of it as a book.....I think you'd rather read it453252<|endoftext|>KAR

HelloKart for the 'World'
Thank you! This is
---
step 40: train loss 4.711186 (took 124.364000 ms)

Process finished with exit code 0

 